### PR TITLE
feat: update RDS cluster parameter group lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,4 +93,8 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameters" {
       apply_method = "pending-reboot"
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
Add a lifecycle block to the RDS cluster parameter group 
to set create_before_destroy to true. This change ensures 
new resources are created before the old ones are destroyed, 
preventing downtime during updates.